### PR TITLE
Change country labels to say jurisdiction instead

### DIFF
--- a/oop/src/components/CountryInput.vue
+++ b/oop/src/components/CountryInput.vue
@@ -3,11 +3,12 @@
     <label :for="id">{{label}}</label><br/>
     <country-select 
       :id="id" 
-      aria-label='Country'
+      aria-label='Jurisdiction'
       name="country"
       class="form-control" 
       v-model="country"
       :country="country"
+      placeholder="Select Jurisdiction"
       :countryName="true"/>
   </div>
 </template>

--- a/oop/src/components/ReviewTableList.vue
+++ b/oop/src/components/ReviewTableList.vue
@@ -128,7 +128,7 @@ export default {
         value: this.$store.state.form.isNewAddressKnown === 'Y' ? 'Yes' : 'No',
       });
       items.push({
-        label: 'Country:',
+        label: 'Jurisdiction:',
         value: this.$store.state.form.country,
       });
       if (this.$store.state.form.country === 'Canada') {

--- a/oop/src/views/MoveInfoPage.vue
+++ b/oop/src/views/MoveInfoPage.vue
@@ -42,7 +42,7 @@
         <div class="row">
           <div class="col-sm-7">
             <div v-if='isNewAddressKnown === "Y"' class="is-new-address-known-y">
-              <CountryInput label='Country'
+              <CountryInput label='Jurisdiction'
                             ref="country"
                             className='mt-3'
                             class="country"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [X] After these changes, the app was run and still works as expected
- [X] Tests for these changes were added (if applicable) (N/A)
- [X] All existing unit tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Changes the word "country" to say Jurisdiction instead.

### Additional Notes:
I found the following places where this needed to happen: The MoveInfo country dropdown (for the label, aria label, and default placeholder option), the Review Page (the label). If I missed anything, please let me know.
