### PR TITLE
CSA-3: Fix invalid PHN display error

### DIFF
--- a/oop/src/components/PhnInputWrapper.vue
+++ b/oop/src/components/PhnInputWrapper.vue
@@ -11,7 +11,7 @@
     />
     <div
       class="text-danger"
-      v-if="v$.phnData.phnValidator.$invalid && v$.phnData.$dirty"
+      v-if="(v$.phnData.phnValidator.$invalid || v$.phnData.phnNineValidator.$invalid) && v$.phnData.$dirty"
       aria-live="assertive"
     >
       This is not a valid Personal Health Number.
@@ -22,6 +22,7 @@
 <script>
 import { PhnInput } from "common-lib-vue";
 import useVuelidate from "@vuelidate/core";
+import { phnNineValidator } from '../helpers/validators';
 import { optionalValidator, phnValidator } from "common-lib-vue";
 
 export default {
@@ -54,6 +55,7 @@ export default {
     const validations = {
       phnData: {
         phnValidator: optionalValidator(phnValidator),
+        phnNineValidator: optionalValidator(phnNineValidator)
       },
     };
     return validations;

--- a/oop/src/helpers/validators.js
+++ b/oop/src/helpers/validators.js
@@ -37,3 +37,14 @@ export const canadaPostalCodeLengthValidator = (value) => {
   }
   return true;
 };
+
+export const phnNineValidator = (value) => {
+  //first digit of PHN needs to be a 9, otherwise trigger validation error
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (value && value[0] === "9") {
+    return true;
+  }
+  return false;
+};

--- a/oop/src/views/YourInfoPage.vue
+++ b/oop/src/views/YourInfoPage.vue
@@ -33,7 +33,7 @@
                 v-if="v$.phn.$dirty && v$.phn.required.$invalid"
                 aria-live="assertive">Personal Health Number is required.</div>
             <div class="text-danger"
-                v-if="v$.phn.$dirty && !v$.phn.required.$invalid && v$.phn.phnValidation.$invalid"
+                v-if="v$.phn.$dirty && !v$.phn.required.$invalid && (v$.phn.phnValidation.$invalid || v$.phn.phnNineValidation.$invalid)"
                 aria-live="assertive">This is not a valid Personal Health Number.</div>
             <div class="text-danger"
                 v-if="isValidationCode1Shown || isValidationCode2Shown"
@@ -92,6 +92,7 @@ import {
   scrollToError,
   getTopScrollPosition
 } from '../helpers/scroll';
+import { phnNineValidator } from '../helpers/validators';
 import PageContent from '../components/PageContent.vue';
 import TipBox from '../components/TipBox.vue';
 import {
@@ -99,7 +100,8 @@ import {
   Input,
   PhnInput,
   PhoneNumberInput,
-  phnValidator
+  phnValidator,
+  optionalValidator
 } from 'common-lib-vue';
 import useVuelidate from "@vuelidate/core";
 import { required } from '@vuelidate/validators';
@@ -190,6 +192,7 @@ export default {
       phn: {
         required,
         phnValidation: phnValidator,
+        phnNineValidation: optionalValidator(phnNineValidator),
       },
       phone: {
         phoneValidator,

--- a/oop/tests/e2e/specs/happypath2.spec.js
+++ b/oop/tests/e2e/specs/happypath2.spec.js
@@ -6,7 +6,7 @@ Cypress.on("uncaught:exception", (err, runnable) => {
 
 //At last check, there is code in the program that checks for dates in the distant future/past
 //To prevent code written in 2021 from failing in 2025 because the date is too far back,
-//this code pull the current year and adjusts it.
+//this code pulls the current year and adjusts it.
 //This is to hopefully increase the stability of the test
 const testYear = new Date().getFullYear() + 1;
 
@@ -95,6 +95,10 @@ describe("Happy path", () => {
     cy.get("[data-cy=continueBar]").click();
     cy.contains("This is not a valid Personal Health Number.");
     cy.get("[data-cy=yourInfoPhn]").clear();
+    cy.get("[data-cy=yourInfoPhn]").type("8999999998");
+    cy.get("[data-cy=continueBar]").click();
+    cy.contains("This is not a valid Personal Health Number.");
+    cy.get("[data-cy=yourInfoPhn]").clear();
 
     cy.get("[data-cy=yourInfoPhone]").type("111");
     cy.get("[data-cy=continueBar]").click();
@@ -129,6 +133,10 @@ describe("Happy path", () => {
     });
     cy.get("[data-cy=continueBar]").click();
     cy.contains("Dependent Personal Health Number is required.");
+    cy.get("[data-cy=phn0]").type("8999 999 998");
+    cy.get("[data-cy=continueBar]").click();
+    cy.contains("This is not a valid Personal Health Number.");
+    cy.get("[data-cy=phn0]").clear();
     cy.get("[data-cy=phn0]").type("9999 999 998");
     cy.get("[data-cy=phn1]").type("9999 999 998");
     cy.get("[data-cy=continueBar]").click();

--- a/oop/tests/unit/views/YourInfoPage.spec.js
+++ b/oop/tests/unit/views/YourInfoPage.spec.js
@@ -495,6 +495,64 @@ describe("YourInfoPage.vue nextPage()", () => {
     expect(spyOnScrollToError).toHaveBeenCalled();
   });
 
+  it("throws an error, does not call api service when phn is invalid", async () => {
+    const store = createStore({
+      modules: {
+        form: {
+          state: {
+            lastName: "Picket Boatxe",
+            phn: "9999 999 999",
+            phone: "2222222222",
+          },
+          namespaced: true,
+        },
+      },
+    });
+    const wrapper = mount(Component, {
+      global: {
+        plugins: [store],
+      },
+    });
+
+    mockApiService.mockImplementation(() => Promise.resolve(mockResponse));
+
+    wrapper.vm.nextPage();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.v$.$invalid).toEqual(true);
+    expect(mockApiService).not.toHaveBeenCalled();
+    expect(spyOnScrollToError).toHaveBeenCalled();
+  });
+
+  it("throws an error, does not call api service when phn passes mod check but starts with a number that's not 9", async () => {
+    const store = createStore({
+      modules: {
+        form: {
+          state: {
+            lastName: "Picket Boatxe",
+            phn: "8999 999 998",
+            phone: "2222222222",
+          },
+          namespaced: true,
+        },
+      },
+    });
+    const wrapper = mount(Component, {
+      global: {
+        plugins: [store],
+      },
+    });
+
+    mockApiService.mockImplementation(() => Promise.resolve(mockResponse));
+
+    wrapper.vm.nextPage();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.v$.$invalid).toEqual(true);
+    expect(mockApiService).not.toHaveBeenCalled();
+    expect(spyOnScrollToError).toHaveBeenCalled();
+  });
+
   it("does call api service when last name and phn are present", async () => {
     const store = createStore({
       modules: {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [x] Tests for these changes were added (if applicable)
- [x] `npm audit` was checked, applicable vulnerabilities were updated
- [x] `npm run build` passes
- [x] `npm run lint` has no unexpected errors
- [x] All existing unit tests were run and still pass (`npm run test:unit`)
- [x] End-to-end tests were run and still pass

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
--creates validator to ensure the first digit of a PHN is 9
--imports validator into the PHN validations used in YourInfoPage and PhnInputWrapper component
--adds logic to display text when validator is triggered

### Additional Notes:
