### PR TITLE
Dynatrace version bump (msp service 1.0.1 -> 2.0.0, splunk forwarder 0.9.1 -> 1.0.0)

### DIFF
--- a/msp-service/package-lock.json
+++ b/msp-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msp-service",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/msp-service/package.json
+++ b/msp-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msp-service",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/splunk-forwarder/package-lock.json
+++ b/splunk-forwarder/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-forwarder",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/splunk-forwarder/package.json
+++ b/splunk-forwarder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-forwarder",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "description": "Forward log request to remove Splunk server",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [x] After these changes, the app was run and still works as expected
- [ ] Tests for these changes were added (if applicable)
- [ ] `npm audit` was checked, applicable vulnerabilities were updated
- [x] `npm run build` passes
- [x] `npm run lint` has no unexpected errors
- [x] All existing unit tests were run and still pass (`npm run test:unit`)
- [x] End-to-end tests were run and still pass in Chrome, Firefox, and Edge without unexpected console errors (`npm run test:e2e`)

### Please specify the type of change this PR introduces (Bug fix, feature addition, content update, chore, etc.):
Version bump

### Additional Notes:
`npm run test:unit` was run for OOP and AOP. `npm run test:e2e` was run for OOP and AOP. `npm run build` was run for splunk-forwarder, msp-service, AOP, and OOP.

`npm audit` was NOT run, as it's out of scope. Any standing vulnerabilities will be addressed in future releases.
